### PR TITLE
Added support for raw Json paramters in endpoints

### DIFF
--- a/WebService-Lib/Attributes/JsonString.cs
+++ b/WebService-Lib/Attributes/JsonString.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace WebService_Lib.Attributes
+{
+    /// <summary>
+    /// Used to Mark string`s in WebService_Lib endpoints that are not plaintext requests
+    /// but Json, that one does not want to be parsed as Dictionary.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class JsonString : Attribute
+    {
+
+    }
+}

--- a/WebService-Lib/Server/RestServer/Request/RequestContext.cs
+++ b/WebService-Lib/Server/RestServer/Request/RequestContext.cs
@@ -42,6 +42,8 @@ namespace WebService_Lib.Server.RestServer
         /// <param name="contentType"></param>
         public static void ParsePayload(ref object? payload, string contentType)
         {
+            // Note: Further Parsing is now done in Mapping`s Invoke function.
+            // This makes it possible to parse more effectively to the requirements (See JsonString).
             switch (contentType)
             {
                 case "text/plain":
@@ -54,24 +56,6 @@ namespace WebService_Lib.Server.RestServer
                     if (payload == null || payload.GetType() != typeof(string))
                     {
                         payload = "{}";
-                    }
-                    // Support for single values
-                    if ((payload as string)!.StartsWith("\""))
-                    {
-                        payload = "{\"value\":" + payload + "}";
-                    }
-                    // Support for arrays
-                    if ((payload as string)!.StartsWith("["))
-                    {
-                        payload = "{\"array\":" + payload + "}";
-                    }
-                    try
-                    {
-                        payload = JsonConvert.DeserializeObject<Dictionary<string, object>>((string) payload);
-                    }
-                    catch (Exception)
-                    {
-                        payload = null;
                     }
                     break;
                 default:


### PR DESCRIPTION
[JsonString] is used to mark strings in WebService_Lib endpoints that are not plaintext requests but Json, that one does not want to be parsed as a Dictionary.